### PR TITLE
replace git-flow with git-flow-avh and adjust instructions accordingly

### DIFF
--- a/index.ca_CA.html
+++ b/index.ca_CA.html
@@ -110,11 +110,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -123,13 +123,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Necessites wget i util-linux per instal·lar git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Per instruccions detallades per instal·lar git flow, visita la <a href="https://github.com/nvie/gitflow/wiki/Windows">wiki de git flow</a>.
+            Per instruccions detallades per instal·lar git flow, visita la <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">wiki de git flow</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.de_DE.html
+++ b/index.de_DE.html
@@ -109,11 +109,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -122,13 +122,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Du benötigst wget und util-linux um git-flow zu installieren.</p>
     </div>
     <div class="col-2">
         <p>
-            Für eine detaillierte git-flow Installationsanleitung, besuche bitte das <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            Für eine detaillierte git-flow Installationsanleitung, besuche bitte das <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.el_GR.html
+++ b/index.el_GR.html
@@ -121,11 +121,11 @@
             <h3>OSX</h3>
             <span>Homebrew</span>
             <blockquote>
-                $ brew install git-flow
+                $ brew install git-flow-avh
             </blockquote>
             <span>Macports</span>
             <blockquote>
-                $ port install git-flow
+                $ port install git-flow-avh
             </blockquote>
             <h3>Linux</h3>
             <blockquote>
@@ -134,14 +134,14 @@
             <h3>Windows (Cygwin)</h3>
             <blockquote>
                 $ wget -q -O - --no-check-certificate
-                https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+                https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
             </blockquote>
             <p>Χρειάζεστε το wget και το util-linux για να εγκαταστήσετε το git-flow.</p>
         </div>
         <div class="col-2">
             <p>
                 Για αναλυτικές οδηγίες εγκατάστασης του git flow παρακαλώ επισκεφτείτε το
-                <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow wiki</a>.
+                <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow wiki</a>.
             </p>
             <img src="img/download.png" alt="install git-flow"/>
         </div>

--- a/index.es_ES.html
+++ b/index.es_ES.html
@@ -110,11 +110,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -123,13 +123,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Necesitarás wget y util-linux para instalar git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Para instrucciones de instalación detalladas, por favor, visite la <a href="https://github.com/nvie/gitflow/wiki/Windows">wiki de git flow</a>
+            Para instrucciones de instalación detalladas, por favor, visite la <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">wiki de git flow</a>
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.fr_FR.html
+++ b/index.fr_FR.html
@@ -109,11 +109,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -122,14 +122,14 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Vous aurez besoin de wget et de util-linux pour installer git-flow.</p>
     </div>
     <div class="col-2">
         <p>
             Pour des instructions détaillées concernant l'installation de git-flow, consultez le
-            <a href="https://github.com/nvie/gitflow/wiki/Windows">wiki git-flow</a>.
+            <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">wiki git-flow</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.hr_HR.html
+++ b/index.hr_HR.html
@@ -112,11 +112,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -125,13 +125,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Trebate wget i util-linux za instaliranje git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Za detaljne instalacijske upute posjetite <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            Za detaljne instalacijske upute posjetite <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.html
+++ b/index.html
@@ -111,11 +111,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -124,13 +124,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>You need wget and util-linux to install git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            For detailed git flow installation instructions please visit the <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            For detailed git flow installation instructions please visit the <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.it_IT.html
+++ b/index.it_IT.html
@@ -109,11 +109,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -122,13 +122,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Sono necessari wget e util-linux per installare git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Per le istruzioni dettagliate riguardo l'installazione di git-flow visitate il <a href="https://github.com/nvie/gitflow/wiki/Windows">wiki di git flow</a>.
+            Per le istruzioni dettagliate riguardo l'installazione di git-flow visitate il <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">wiki di git flow</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.ja_JP.html
+++ b/index.ja_JP.html
@@ -108,11 +108,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -121,13 +121,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>git-flowのインストールには、wgetとutil-linuxが必要です。</p>
     </div>
     <div class="col-2">
         <p>
-            詳細なgit flowのインストール方法は以下のサイトを参考にしてください。 <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            詳細なgit flowのインストール方法は以下のサイトを参考にしてください。 <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.ko_KR.html
+++ b/index.ko_KR.html
@@ -108,11 +108,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -121,13 +121,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>git-flow의 설치를 위해서는 wget과 util-linux가 필요합니다.</p>
     </div>
     <div class="col-2">
         <p>
-            상세한 git flow의 설치 방법은 <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow wiki</a>를 참고하세요.
+            상세한 git flow의 설치 방법은 <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow wiki</a>를 참고하세요.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.nl_NL.html
+++ b/index.nl_NL.html
@@ -110,11 +110,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -123,13 +123,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Je hebt wget en util-linux nodig om git-flow te installeren.</p>
     </div>
     <div class="col-2">
         <p>
-            Gedetailleerde installatie instructies voor git flow kun je vinden op de<a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            Gedetailleerde installatie instructies voor git flow kun je vinden op de<a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.pl_PL.html
+++ b/index.pl_PL.html
@@ -115,11 +115,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -128,14 +128,14 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Potrzebujesz wget oraz util-linux żeby zainstalować git-flow.</p>
     </div>
     <div class="col-2">
         <p>
             Szczegółową instrukcję instalacji git możesz znaleźć na 
-            <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow wiki</a>.
+            <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.pt_BR.html
+++ b/index.pt_BR.html
@@ -94,11 +94,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -107,13 +107,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
     </div>
     <div class="col-2">
         <p>
             Para instruções detalhadas sobre a instalação, visite
-            a <a href="https://github.com/nvie/gitflow/wiki/Windows">wiki
+            a <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">wiki
             do git-flow</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.ro_RO.html
+++ b/index.ro_RO.html
@@ -109,11 +109,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -122,13 +122,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Vei avea nevoie de wget și de util-linux pentru a instala git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Pentru instrucțiuni detaliate de instalare a git flow te rugăm să vizitezi <a href="https://github.com/nvie/gitflow/wiki/Windows">wiki-ul git flow</a>.
+            Pentru instrucțiuni detaliate de instalare a git flow te rugăm să vizitezi <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">wiki-ul git flow</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.ru_RU.html
+++ b/index.ru_RU.html
@@ -118,11 +118,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -131,13 +131,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Вам потребуется wget и util-linux для установки git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Подробные инструкции по установке git flow смотрите на <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            Подробные инструкции по установке git flow смотрите на <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.tr_TR.html
+++ b/index.tr_TR.html
@@ -115,11 +115,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -128,14 +128,14 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Git flow kurulumu için wget ve util-linux gerekmektedir.</p>
     </div>
     <div class="col-2">
         <p>
             Git-flow kurulumu hakkında detaylı bilgi için git flow wiki'yi
-            ziyaret edebilirsiniz.<a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            ziyaret edebilirsiniz.<a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.uk_UK.html
+++ b/index.uk_UK.html
@@ -118,11 +118,11 @@
             <h3>OSX</h3>
             <span>Homebrew</span>
             <blockquote>
-                $ brew install git-flow
+                $ brew install git-flow-avh
             </blockquote>
             <span>Macports</span>
             <blockquote>
-                $ port install git-flow
+                $ port install git-flow-avh
             </blockquote>
             <h3>Linux</h3>
             <blockquote>
@@ -131,13 +131,13 @@
             <h3>Windows (Cygwin)</h3>
             <blockquote>
                 $ wget -q -O - --no-check-certificate
-                https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+                https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
             </blockquote>
             <p>Вам знадобиться wget і util-linux для установки git-flow.</p>
         </div>
         <div class="col-2">
             <p>
-                Докладні інструкції для встановлення git flow дивіться на <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+                Докладні інструкції для встановлення git flow дивіться на <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
                 wiki</a>.
             </p>
             <img src="img/download.png" alt="install git-flow"/>

--- a/index.vi_VN.html
+++ b/index.vi_VN.html
@@ -108,11 +108,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -121,13 +121,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>Bạn cần wget và util-linux để cài đặt git-flow.</p>
     </div>
     <div class="col-2">
         <p>
-            Xem chi tiết về cách cài đặt git flow ở trang sau: <a href="https://github.com/nvie/gitflow/wiki/Windows">git flow
+            Xem chi tiết về cách cài đặt git flow ở trang sau: <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation">git flow
             wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>

--- a/index.zh_CN.html
+++ b/index.zh_CN.html
@@ -95,11 +95,11 @@
         <h3>OSX</h3>
         <span>Homebrew</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>Macports</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -108,13 +108,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>安装 git-flow, 你需要 wget 和 util-linux。</p>
     </div>
     <div class="col-2">
         <p>
-            更多的 git flow 安装指引，请阅读  <a href="https://github.com/nvie/gitflow/wiki/Windows" target="_blank">git flow wiki</a>.
+            更多的 git flow 安装指引，请阅读  <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation" target="_blank">git flow wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>

--- a/index.zh_TW.html
+++ b/index.zh_TW.html
@@ -98,11 +98,11 @@
         <h3>Mac OS X</h3>
         <span>透過 Homebrew 安裝</span>
         <blockquote>
-            $ brew install git-flow
+            $ brew install git-flow-avh
         </blockquote>
         <span>透過 Macports 安裝</span>
         <blockquote>
-            $ port install git-flow
+            $ port install git-flow-avh
         </blockquote>
         <h3>Linux</h3>
         <blockquote>
@@ -111,13 +111,13 @@
         <h3>Windows (Cygwin)</h3>
         <blockquote>
             $ wget -q -O - --no-check-certificate
-            https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+            https://raw.github.com/petervanderdoes/gitflow-avh/develop/contrib/gitflow-installer.sh install stable | bash
         </blockquote>
         <p>在 Windows 下安装 git-flow, 你會需要 wget 和 util-linux。</p>
     </div>
     <div class="col-2">
         <p>
-            更詳細的 git-flow 安裝指南，請參閱  <a href="https://github.com/nvie/gitflow/wiki/Windows" target="_blank">git flow wiki</a>.
+            更詳細的 git-flow 安裝指南，請參閱  <a href="https://github.com/petervanderdoes/gitflow-avh/wiki/Installation" target="_blank">git flow wiki</a>.
         </p>
         <img src="img/download.png" alt="install git-flow"/>
     </div>


### PR DESCRIPTION
The initial toolset of git-flow at https://github.com/nvie/gitflow is not developed any further (i.e. dead). The last commit is 4 years old.
There are several big issues with the old git-flow tool, the most daunting (i.e. `git describe`does not work):
- https://github.com/nvie/gitflow/issues/49
- https://github.com/nvie/gitflow/issues/126

The old git-flow does also not support git-flow-specific hooks:
- https://github.com/nvie/gitflow/issues/60

The git-flow AVH Edition from https://github.com/petervanderdoes/gitflow-avh seems to be the commonly agreed on successor to git-flow and is a fork of the original git-flow that addresses these problems. It is backward-compatible with the original git-flow and addresses the above problems. 

Therefore I changed the installation instructions and changed them to install git-flow-avh. I have used the instructions from: https://github.com/petervanderdoes/gitflow-avh/wiki/Installation for the individual platforms. However as I am on OS X, I have only tested OS X (ports + brew). The [instructions for Linux](https://github.com/petervanderdoes/gitflow-avh/wiki/Installing-on-Linux,-Unix,-etc.) mention, that on a current Ubuntu `apt-get install git-flow` will install the AVH edition of git-flow anyway. That's why I did not change the Linux installation instructions.

Your cheat-sheet is nice and we use it at work for new developers and maybe you consider making the switch to git-flow-avh as well.
