### PR TITLE
Minor spanish corrections.

### DIFF
--- a/index.es_ES.html
+++ b/index.es_ES.html
@@ -177,7 +177,7 @@
         <blockquote>
             git flow feature start MYFEATURE
         </blockquote>
-        <p>Esta acción crea una nueva rama derivada de 'develop' y luego cambia el código a esta rama.</p>
+        <p>Esta acción crea una nueva rama derivada de 'develop' y salta a esta, estableciéndola como rama de trabajo actual.</p>
 
         <!--
         - Bump the version number now!
@@ -197,16 +197,16 @@
 
 <div class="scrollblock">
     <div class="col-1">
-        <h3>Terminar una característica</h3>
+        <h3>Finalizar una característica</h3>
 
         <p>
-            Terminar el desarrollo de una característica.
+            Finaliza el desarrollo de una característica.
             Esta acción realiza lo siguiente:
         </p>
         <ul>
             <li>Fusiona MYFEATURE en 'develop'</li>
             <li>Borra la rama MYFEATURE</li>
-            <li>Establece como versión de trabajo la rama 'develop'</li>
+            <li>Salta a la rama 'develop', estableciéndola como rama de trabajo actual</li>
         </ul>
 
         <blockquote>
@@ -241,7 +241,7 @@
         <h3>Obteniendo características publicadas</h3>
 
         <p>
-            Descarga una característica publicada por otro y mantiene un seguimiento de sus cambios.
+            Obtiene una característica publicada por otro y mantiene un seguimiento de sus cambios.
         </p>
 
         <blockquote>
@@ -255,7 +255,7 @@
 
 
 <div class="scrollblock">
-    <h2><a name="release" href="#release">Publica una versión</a></h2>
+    <h2><a name="release" href="#release">Publicar una versión</a></h2>
 
     <ul>
         <li>Prepara una versión para producción</li>
@@ -263,7 +263,7 @@
     </ul>
     <p class="divider">&#9733; &#9733; &#9733;</p>
     <div class="col-1">
-        <h3>Comienza una publicación</h3>
+        <h3>Comenzar una publicación</h3>
 
         <p>Para comenzar una publicación, usa el comando git flow release. Creará</p>
         una rama de publicación derivada de la rama 'develop'.
@@ -278,7 +278,7 @@
         <blockquote>
             git flow release publish RELEASE
         </blockquote>
-        <p>(Puede establecer el seguimiento de los cambios de la publicación remota utilizando el comando <br/><code>git flow release track RELEASE</code></p>
+        <p>(Puede establecer el seguimiento de los cambios de la publicación remota utilizando el comando <br/><code>git flow release track RELEASE</code>)</p>
     </div>
     <div class="col-2">
         <div class="release-start"></div>


### PR DESCRIPTION
-Follow spanish version of Pro Git book naming convention.
-Infinitive verbs in all titles to keep consistency.
-'Finalizar' better than 'Terminar' in this context.
-'Obtiene' better than 'Descarga' in this context.
