### PR TITLE
Fix link to cheat sheet GitHub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 git-flow-cheatsheet
 ===================
 
-A cheatsheet on the usage of git flow, visit http://danielkummer.github.com/git-flow-cheatsheet/
+A cheatsheet on the usage of git flow, visit [https://danielkummer.github.io/git-flow-cheatsheet/](https://danielkummer.github.io/git-flow-cheatsheet/)
 
 GIT FLOW
 ========


### PR DESCRIPTION
Fixed the link which was pointing to github.com instead of github.io

 - also use http/ssl against http